### PR TITLE
Use MultiBlock container

### DIFF
--- a/pyiges/iges.py
+++ b/pyiges/iges.py
@@ -30,7 +30,7 @@ class Iges():
 
             return pyvista.wrap(afilter.GetOutput())
 
-        return items
+        return pyvista.MultiBlock(items)
 
     @property
     def bsplines(self):

--- a/pyiges/iges.py
+++ b/pyiges/iges.py
@@ -14,7 +14,7 @@ class Iges():
 
     def to_vtk(self, bsplines=True, surfaces=True, delta=0.025, merge=True):
         """Converts entities to vtk object"""
-        items = []
+        items = pyvista.MultiBlock()
         for entity in tqdm(self, desc='Converting entities to vtk'):
             if isinstance(entity, RationalBSplineCurve) and bsplines:
                 items.append(entity.to_vtk(delta))
@@ -30,7 +30,7 @@ class Iges():
 
             return pyvista.wrap(afilter.GetOutput())
 
-        return pyvista.MultiBlock(items)
+        return items
 
     @property
     def bsplines(self):


### PR DESCRIPTION
When `merge` is False, use a `pyvista.MultiBlock` container to make plotting and everything easier.

Currently, I am trying to think of a way to find the watertight regions of the mesh and trim out all the other parts...

```py
import pyiges
from pyiges import examples

# load an example impeller
iges = pyiges.read(examples.impeller)

# convert all surfaces to a vtk mesh and plot it
mesh = iges.to_vtk(bsplines=False, surfaces=True, merge=False, delta=0.05)
mesh.plot(smooth_shading=True, multi_colors=True)
```

![download](https://user-images.githubusercontent.com/22067021/69117427-daa10780-0a4c-11ea-8e25-20e9632f80e1.png)

