### PR TITLE
Status number parsing for entities

### DIFF
--- a/pyiges/entity.py
+++ b/pyiges/entity.py
@@ -45,7 +45,7 @@ class Entity():
             # It includes spaces, so  0 0 0 0 is a valid 8-digit for which int casting won't work.
             if key == "status_number":
                 # Get a list of four 2-digit numbers with spaces removed.
-                separated_status_numbers = [string[i:i+2].replace(' ', '') for i in range(0, len(string), 2)]
+                separated_status_numbers = [string[i:i+2].replace(' ', '0') for i in range(0, len(string), 2)]
                 
                 # Join these status numbers together as a single string.
                 status_number_string = ''.join(separated_status_numbers)

--- a/pyiges/entity.py
+++ b/pyiges/entity.py
@@ -52,7 +52,7 @@ class Entity():
 
                 # The string can now be properly cast as an int
                 self.d[key] = int(status_number_string)
-            if len(string) > 0:
+            elif len(string) > 0:
                 self.d[key] = int(string)
             else:
                 self.d[key] = None

--- a/pyiges/entity.py
+++ b/pyiges/entity.py
@@ -41,6 +41,17 @@ class Entity():
         if type == 'string':
             self.d[key] = string
         else:
+            # Status numbers are made of four 2-digit numbers, together making an 8-digit number.
+            # It includes spaces, so  0 0 0 0 is a valid 8-digit for which int casting won't work.
+            if key == "status_number":
+                # Get a list of four 2-digit numbers with spaces removed.
+                separated_status_numbers = [string[i:i+2].replace(' ', '') for i in range(0, len(string), 2)]
+                
+                # Join these status numbers together as a single string.
+                status_number_string = ''.join(separated_status_numbers)
+
+                # The string can now be properly cast as an int
+                self.d[key] = int(status_number_string)
             if len(string) > 0:
                 self.d[key] = int(string)
             else:


### PR DESCRIPTION
From this article about the IGES specification http://www.learnicem.com/iges-format.html

D-section
Line 1, Field 9: Status. 4x2-digit values to form 8-digit number, no spaces.

These changes prevent a casting error for status numbers that have spaces in them.