### PR TITLE
Fix RationalBSplineSurface.__repr__

### DIFF
--- a/pyiges/geometry.py
+++ b/pyiges/geometry.py
@@ -542,6 +542,7 @@ class RationalBSplineSurface(Entity):
         info += '    v1: %f\n' % self.v1
 
         info += '    Control Points: %d' % len(self._cp)
+        return info
 
     def to_geomdl(self):
         """Return a ``geommdl.BSpline.Surface``"""

--- a/pyiges/iges.py
+++ b/pyiges/iges.py
@@ -212,9 +212,6 @@ class Iges():
 
         return items
 
-    def __getitem__(self, indices):
-        return self._entities[indices]
-
     def __iter__(self):
         for entity in self._entities:
             yield entity


### PR DESCRIPTION
Fixed a simple bug, which causes exceptions when `repr` is used. It is critical, as it also obfuscates other exceptions which try to include the `RationalBSplineSurface` objects in their message.

Also I removed an overriden definition of `Iges.__getitem__` which has no effect. 