### PR TITLE
Fix VTK import

### DIFF
--- a/pyiges/check_imports.py
+++ b/pyiges/check_imports.py
@@ -1,7 +1,7 @@
 try:
     import geomdl
     import pyvista
-    from vtk import vtkAppendPolyData
+    from vtkmodules.vtkFiltersCore import vtkAppendPolyData
 
     _IS_FULL_MODULE = True
 except (ModuleNotFoundError, ImportError) as exc:

--- a/pyiges/check_imports.py
+++ b/pyiges/check_imports.py
@@ -1,7 +1,7 @@
 try:
     import geomdl
     import pyvista
-    from pyvista._vtk import vtkAppendPolyData
+    from vtk import vtkAppendPolyData
 
     _IS_FULL_MODULE = True
 except (ModuleNotFoundError, ImportError) as exc:


### PR DESCRIPTION
Adapts VTK import, since `pyvista._vtk` was removed in the latest version. Closes #36 