### PR TITLE
Use PyPI OIDC

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: '3.13'
 
     - name: Build package
       run: |

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -44,15 +44,33 @@ jobs:
         flit build
         twine check dist/*
 
-    - name: Upload to PyPi
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+  pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    needs: [unit_tests]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyiges
+    permissions:
+      id-token: write # this permission is mandatory for trusted publishing
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+
+    - name: Build package
       run: |
-        pip install twine
-        twine upload --skip-existing dist/pyiges*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
-        TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
+        pip install flit
+        flit build
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
 
   Release:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')


### PR DESCRIPTION
## Summary

Migrate PyPI publishing from token-based `twine upload` to OIDC Trusted Publishing via `pypa/gh-action-pypi-publish`. The upload previously ran inside the matrix `unit_tests` job; it now lives in a dedicated `pypi` job with `permissions: id-token: write` and `environment: pypi`, so it publishes exactly once per tag.

## Next steps

- [x] Add a Trusted Publisher on PyPI for this project: Account → Publishing → Add a new publisher (workflow: `testing-and-deployment.yml`, environment: `pypi`).
- [x] Add `pyiges` to the `pyvista` PyPI organization.
- [x] After first successful OIDC release, delete the old PyPI API token and revoke the `TWINE_TOKEN` Actions secret.